### PR TITLE
Allow to run assertion on Optional value

### DIFF
--- a/src/main/java/org/assertj/guava/api/OptionalAssert.java
+++ b/src/main/java/org/assertj/guava/api/OptionalAssert.java
@@ -12,11 +12,14 @@
  */
 package org.assertj.guava.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.guava.error.OptionalShouldBeAbsent.shouldBeAbsent;
 import static org.assertj.guava.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.guava.error.OptionalShouldBePresentWithValue.shouldBePresentWithValue;
 
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.util.VisibleForTesting;
@@ -52,16 +55,16 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * Verifies that the actual {@link Optional} contains the given value.<br>
    * <p>
    * Example :
-   * 
+   *
    * <pre><code class='java'>
    * Optional&lt;String&gt; optional = Optional.of(&quot;Test&quot;);
    *
    * assertThat(optional).contains(&quot;Test&quot;);
    * </code></pre>
-   * 
+   *
    * @param value the value to look for in actual {@link Optional}.
    * @return this {@link OptionalAssert} for assertions chaining.
-   * 
+   *
    * @throws AssertionError if the actual {@link Optional} is {@code null}.
    * @throws AssertionError if the actual {@link Optional} contains nothing or does not have the given value.
    */
@@ -80,15 +83,15 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * Verifies that the actual {@link Optional} contained instance is absent/null (ie. not {@link Optional#isPresent()}).<br>
    * <p>
    * Example :
-   * 
+   *
    * <pre><code class='java'>
    * Optional&lt;String&gt; optional = Optional.absent();
    *
    * assertThat(optional).isAbsent();
    * </code></pre>
-   * 
+   *
    * @return this {@link OptionalAssert} for assertions chaining.
-   * 
+   *
    * @throws AssertionError if the actual {@link Optional} is {@code null}.
    * @throws AssertionError if the actual {@link Optional} contains a (non-null) instance.
    */
@@ -104,15 +107,15 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
    * Verifies that the actual {@link Optional} contains a (non-null) instance.<br>
    * <p>
    * Example :
-   * 
+   *
    * <pre><code class='java'>
    * Optional&lt;String&gt; optional = Optional.of(&quot;value&quot;);
    *
    * assertThat(optional).isPresent();
    * </code></pre>
-   * 
+   *
    * @return this {@link OptionalAssert} for assertions chaining.
-   * 
+   *
    * @throws AssertionError if the actual {@link Optional} is {@code null}.
    * @throws AssertionError if the actual {@link Optional} contains a null instance.
    */
@@ -122,6 +125,51 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
       throw failures.failure(info, shouldBePresent(actual));
     }
     return this;
+  }
+
+  /**
+   * Chain assertion on the content of the Optional<br>
+   * <p>
+   * Example :
+   *
+   * <pre><code class='java'>
+   * Optional&lt;Number&gt; optional = Optional.of(12L);
+   *
+   * assertThat(optional).extractingValue().isInstanceOf(Long.class);
+   * </code></pre>
+   *
+   * </p>
+   *
+   * @return a new {@link AbstractObjectAssert} for assertions chaining on the content of the Optional.
+   * @throws AssertionError if the actual {@link Optional} is {@code null}.
+   * @throws AssertionError if the actual {@link Optional} contains a null instance.
+   */
+  public AbstractObjectAssert<?, T> extractingValue() {
+    isPresent();
+    return assertThat(actual.get());
+  }
+
+  /**
+   * Chain assertion on the content of the Optional<br>
+   * <p>
+   * Example :
+   *
+   * <pre><code class='java'>
+   * Optional&lt;String&gt; optional = Optional.of("Bill");
+   *
+   * assertThat(optional).extractingCharSequence().startsWith("Bi");
+   * </code></pre>
+   *
+   * </p>
+   *
+   * @return a new {@link AbstractCharSequenceAssert} for assertions chaining on the content of the Optional.
+   * @throws AssertionError if the actual {@link Optional} is {@code null}.
+   * @throws AssertionError if the actual {@link Optional} contains a null instance.
+   */
+  public AbstractCharSequenceAssert<?, ? extends CharSequence> extractingCharSequence() {
+    isPresent();
+    assertThat(actual.get()).isInstanceOf(CharSequence.class);
+    return assertThat((CharSequence) actual.get());
   }
 
 }

--- a/src/test/java/org/assertj/guava/api/OptionalAssert_extractingCharSequence_Test.java
+++ b/src/test/java/org/assertj/guava/api/OptionalAssert_extractingCharSequence_Test.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import com.google.common.base.Optional;
+
+import org.junit.Test;
+
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+/**
+ */
+public class OptionalAssert_extractingCharSequence_Test extends BaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    // given
+    Optional<String> actual = null;
+    // expect
+    expectException(AssertionError.class, actualIsNull());
+    // when
+    assertThat(actual).extractingCharSequence();
+  }
+
+  @Test
+  public void should_fail_when_optional_contains_nothing() {
+    // given
+    final Optional<String> testedOptional = Optional.absent();
+    // expect
+    expectException(AssertionError.class,
+            "Expecting Optional to contain a non-null instance but contained nothing (absent Optional)");
+    // when
+    assertThat(testedOptional).extractingCharSequence();
+  }
+
+  @Test
+  public void should_pass_when_actual_contains_a_value() {
+    // given
+    final Optional<String> testedOptional = Optional.of("Test");
+    // when
+    assertThat(testedOptional).extractingCharSequence();
+    // then pass
+  }
+
+  @Test
+  public void should_not_pass_when_actual_contains_other_than_charSequence() {
+    // given
+    final Optional<? extends Number> testedOptional = Optional.of(12L);
+    // expect
+    expectException(AssertionError.class, "");
+    // when
+    assertThat(testedOptional).extractingCharSequence();
+    // then pass
+  }
+}

--- a/src/test/java/org/assertj/guava/api/OptionalAssert_extractingValue_Test.java
+++ b/src/test/java/org/assertj/guava/api/OptionalAssert_extractingValue_Test.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2014 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import com.google.common.base.Optional;
+
+import org.junit.Test;
+
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+/**
+ */
+public class OptionalAssert_extractingValue_Test extends BaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    // given
+    Optional<String> actual = null;
+    // expect
+    expectException(AssertionError.class, actualIsNull());
+    // when
+    assertThat(actual).extractingValue();
+  }
+
+  @Test
+  public void should_fail_when_optional_contains_nothing() {
+    // given
+    final Optional<String> testedOptional = Optional.absent();
+    // expect
+    expectException(AssertionError.class,
+            "Expecting Optional to contain a non-null instance but contained nothing (absent Optional)");
+    // when
+    assertThat(testedOptional).extractingValue();
+  }
+
+  @Test
+  public void should_pass_when_actual_contains_a_value() {
+    // given
+    final Optional<String> testedOptional = Optional.of("Test");
+    // when
+    assertThat(testedOptional).extractingValue();
+    // then pass
+  }
+}


### PR DESCRIPTION
Hi,

if you like the idea, we can declinate to more methods, like
presentStringAssert()
presentIterableAssert()

etc

Because of type erasure, we cannot declare a generic presentAssert(Class<String) clazz), presentAssert(Class<Iterable> clazz);
etc

Perhaps you have a better proposal ?