### PR TITLE
Make error message OS agnostic: use String.format and %n instead of \…

### DIFF
--- a/src/main/java/org/assertj/guava/error/OptionalShouldBePresentWithValue.java
+++ b/src/main/java/org/assertj/guava/error/OptionalShouldBePresentWithValue.java
@@ -27,7 +27,7 @@ import com.google.common.base.Optional;
 public final class OptionalShouldBePresentWithValue extends BasicErrorMessageFactory {
 
   public static <T> ErrorMessageFactory shouldBePresentWithValue(final Optional<T> actual, final Object value) {
-    return new OptionalShouldBePresentWithValue("\nExpecting Optional to contain value \n<%s>\n but contained \n<%s>",
+    return new OptionalShouldBePresentWithValue("%nExpecting Optional to contain value %n<%s>%n but contained %n<%s>",
         value, actual.get());
   }
 

--- a/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheLowerBound.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheLowerBound.java
@@ -21,7 +21,7 @@ public class RangeShouldBeClosedInTheLowerBound extends BasicErrorMessageFactory
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveClosedLowerBound(final Range<T> actual) {
     return new RangeShouldBeClosedInTheLowerBound(
-        "\nExpecting:\n  <%s>\nto be closed in the lower bound but was opened", actual);
+        "%nExpecting:%n  <%s>%nto be closed in the lower bound but was opened", actual);
   }
 
   /**

--- a/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheUpperBound.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheUpperBound.java
@@ -21,7 +21,7 @@ public class RangeShouldBeClosedInTheUpperBound extends BasicErrorMessageFactory
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveClosedUpperBound(final Range<T> actual) {
     return new RangeShouldBeClosedInTheUpperBound(
-        "\nExpecting:\n  <%s>\nto be closed in the upper bound but was opened", actual);
+        "%nExpecting:%n  <%s>%nto be closed in the upper bound but was opened", actual);
   }
 
   /**

--- a/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheLowerBound.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheLowerBound.java
@@ -21,7 +21,7 @@ public class RangeShouldBeOpenedInTheLowerBound extends BasicErrorMessageFactory
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveOpenedLowerBound(final Range<T> actual) {
     return new RangeShouldBeOpenedInTheLowerBound(
-        "\nExpecting:\n  <%s>\nto be opened in the lower bound but was closed", actual);
+        "%nExpecting:%n  <%s>%nto be opened in the lower bound but was closed", actual);
   }
 
   /**

--- a/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheUpperBound.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheUpperBound.java
@@ -21,7 +21,7 @@ public class RangeShouldBeOpenedInTheUpperBound extends BasicErrorMessageFactory
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveOpenedUpperBound(final Range<T> actual) {
     return new RangeShouldBeOpenedInTheUpperBound(
-        "\nExpecting:\n  <%s>\nto be opened in the upper bound but was closed", actual);
+        "%nExpecting:%n  <%s>%nto be opened in the upper bound but was closed", actual);
   }
 
   /**

--- a/src/main/java/org/assertj/guava/error/RangeShouldHaveLowerEndpointEqual.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldHaveLowerEndpointEqual.java
@@ -21,12 +21,12 @@ public class RangeShouldHaveLowerEndpointEqual extends BasicErrorMessageFactory 
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveEqualLowerEndpoint(final Range<T> actual,
 	                                                                                       final Object value) {
-	return new RangeShouldHaveLowerEndpointEqual("\n" +
-	                                             "Expecting:\n" +
-	                                             "  <%s>\n" +
-	                                             "to have lower endpoint equal to:\n" +
-	                                             "  <%s>\n" +
-	                                             "but was:\n" +
+	return new RangeShouldHaveLowerEndpointEqual("%n" +
+	                                             "Expecting:%n" +
+	                                             "  <%s>%n" +
+	                                             "to have lower endpoint equal to:%n" +
+	                                             "  <%s>%n" +
+	                                             "but was:%n" +
 	                                             "  <%s>",
 	                                             actual, value, actual.lowerEndpoint());
   }

--- a/src/main/java/org/assertj/guava/error/RangeShouldHaveUpperEndpointEqual.java
+++ b/src/main/java/org/assertj/guava/error/RangeShouldHaveUpperEndpointEqual.java
@@ -21,12 +21,12 @@ public class RangeShouldHaveUpperEndpointEqual extends BasicErrorMessageFactory 
 
   public static <T extends Comparable<T>> ErrorMessageFactory shouldHaveEqualUpperEndpoint(final Range<T> actual,
 	                                                                                       final Object value) {
-	return new RangeShouldHaveUpperEndpointEqual("\n" +
-	                                             "Expecting:\n" +
-	                                             "  <%s>\n" +
-	                                             "to have upper endpoint equal to:\n" +
-	                                             "  <%s>\n" +
-	                                             "but was:\n" +
+	return new RangeShouldHaveUpperEndpointEqual("%n" +
+	                                             "Expecting:%n" +
+	                                             "  <%s>%n" +
+	                                             "to have upper endpoint equal to:%n" +
+	                                             "  <%s>%n" +
+	                                             "but was:%n" +
 	                                             "  <%s>",
 	                                             actual, value, actual.upperEndpoint());
   }

--- a/src/main/java/org/assertj/guava/error/ShouldContainKeys.java
+++ b/src/main/java/org/assertj/guava/error/ShouldContainKeys.java
@@ -26,11 +26,11 @@ import org.assertj.core.error.ErrorMessageFactory;
 public class ShouldContainKeys extends BasicErrorMessageFactory {
 
   private ShouldContainKeys(Object actual, Object key) {
-    super("\nExpecting:\n  <%s>\nto contain key:\n  <%s>", actual, key);
+    super("%nExpecting:%n  <%s>%nto contain key:%n  <%s>", actual, key);
   }
 
   private ShouldContainKeys(Object actual, Object[] keys, Set<?> keysNotFound) {
-    super("\nExpecting:\n  <%s>\nto contain keys:\n  <%s>\nbut could not find:\n  <%s>", actual, keys, keysNotFound);
+    super("%nExpecting:%n  <%s>%nto contain keys:%n  <%s>%nbut could not find:%n  <%s>", actual, keys, keysNotFound);
   }
 
   /**

--- a/src/main/java/org/assertj/guava/error/ShouldContainValues.java
+++ b/src/main/java/org/assertj/guava/error/ShouldContainValues.java
@@ -38,10 +38,10 @@ public class ShouldContainValues extends BasicErrorMessageFactory {
   }
 
   private ShouldContainValues(Object actual, Object value) {
-    super("\nExpecting:\n  <%s>\nto contain value:\n  <%s>", actual, value);
+    super("%nExpecting:%n  <%s>%nto contain value:%n  <%s>", actual, value);
   }
 
   private ShouldContainValues(Object actual, Object[] values, Set<?> valuesNotFound) {
-    super("\nExpecting:\n  <%s>\nto contain values:\n  <%s>\nbut could not find:\n  <%s>", actual, values, valuesNotFound);
+    super("%nExpecting:%n  <%s>%nto contain values:%n  <%s>%nbut could not find:%n  <%s>", actual, values, valuesNotFound);
   }
 }

--- a/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
+++ b/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
@@ -38,6 +38,6 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
   private ShouldHaveSize(Object actual, long actualSize, long expectedSize) {
     // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
     // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
-    super(format("\nExpected size:<%s> but was:<%s> in:\n<%s>", expectedSize, actualSize, "%s"), actual);
+    super(format("%nExpected size:<%s> but was:<%s> in:%n<%s>", expectedSize, actualSize, "%s"), actual);
   }
 }

--- a/src/main/java/org/assertj/guava/error/TableShouldContainCell.java
+++ b/src/main/java/org/assertj/guava/error/TableShouldContainCell.java
@@ -39,7 +39,7 @@ public class TableShouldContainCell extends BasicErrorMessageFactory {
 
   private <R,C,V> TableShouldContainCell(Table<R,C,V> actual, R row, C column, V expectedValue, V actualValue) {
     // Except for actual, format values using the standard representation instead of a specific one like Hexadecimal
-    super(format("\nExpecting row:<%s> and column:<%s> to have value:\n  <%s>\nbut was:\n  <%s>\nin:\n  <%s>", row, column, expectedValue, actualValue, "%s"), actual);
+    super(format("%nExpecting row:<%s> and column:<%s> to have value:%n  <%s>%nbut was:%n  <%s>%nin:%n  <%s>", row, column, expectedValue, actualValue, "%s"), actual);
   }
 
 }

--- a/src/main/java/org/assertj/guava/error/TableShouldContainColumns.java
+++ b/src/main/java/org/assertj/guava/error/TableShouldContainColumns.java
@@ -28,10 +28,10 @@ public class TableShouldContainColumns extends BasicErrorMessageFactory {
   }
 
   private TableShouldContainColumns(Object actual, Object row) {
-    super("\nExpecting:\n  <%s>\nto contain column:\n  <%s>", actual, row);
+    super("%nExpecting:%n  <%s>%nto contain column:%n  <%s>", actual, row);
   }
 
   public TableShouldContainColumns(Object actual, Object[] rows, Set<?> columnsNotFound) {
-    super("\nExpecting:\n  <%s>\nto contain columns:\n  <%s>\nbut could not find:\n  <%s>", actual, rows, columnsNotFound);
+    super("%nExpecting:%n  <%s>%nto contain columns:%n  <%s>%nbut could not find:%n  <%s>", actual, rows, columnsNotFound);
   }
 }

--- a/src/main/java/org/assertj/guava/error/TableShouldContainRows.java
+++ b/src/main/java/org/assertj/guava/error/TableShouldContainRows.java
@@ -29,10 +29,10 @@ public class TableShouldContainRows extends BasicErrorMessageFactory {
   }
 
   private TableShouldContainRows(Object actual, Object row) {
-    super("\nExpecting:\n  <%s>\nto contain row:\n  <%s>", actual, row);
+    super("%nExpecting:%n  <%s>%nto contain row:%n  <%s>", actual, row);
   }
 
   public TableShouldContainRows(Object actual, Object[] rows, Set<?> rowsNotFound) {
-    super("\nExpecting:\n  <%s>\nto contain rows:\n  <%s>\nbut could not find:\n  <%s>", actual, rows, rowsNotFound);
+    super("%nExpecting:%n  <%s>%nto contain rows:%n  <%s>%nbut could not find:%n  <%s>", actual, rows, rowsNotFound);
   }
 }

--- a/src/main/java/org/assertj/guava/error/TableShouldHaveColumnCount.java
+++ b/src/main/java/org/assertj/guava/error/TableShouldHaveColumnCount.java
@@ -36,7 +36,7 @@ public class TableShouldHaveColumnCount extends BasicErrorMessageFactory {
   private TableShouldHaveColumnCount(Object actual, int actualSize, int expectedSize) {
     // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
     // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
-    super(format("\nExpected column count:<%s> but was:<%s> in:\n<%s>", expectedSize, actualSize, "%s"), actual);
+    super(format("%nExpected column count:<%s> but was:<%s> in:%n<%s>", expectedSize, actualSize, "%s"), actual);
   }
 
 }

--- a/src/main/java/org/assertj/guava/error/TableShouldHaveRowCount.java
+++ b/src/main/java/org/assertj/guava/error/TableShouldHaveRowCount.java
@@ -36,7 +36,7 @@ public class TableShouldHaveRowCount extends BasicErrorMessageFactory {
   private TableShouldHaveRowCount(Object actual, int actualSize, int expectedSize) {
     // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
     // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
-    super(format("\nExpected row count:<%s> but was:<%s> in:\n<%s>", expectedSize, actualSize, "%s"), actual);
+    super(format("%nExpected row count:<%s> but was:<%s> in:%n<%s>", expectedSize, actualSize, "%s"), actual);
   }
 
 }

--- a/src/test/java/org/assertj/guava/api/ByteSourceAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/guava/api/ByteSourceAssert_hasSize_Test.java
@@ -48,9 +48,9 @@ public class ByteSourceAssert_hasSize_Test extends BaseTest {
     try {
       assertThat(ByteSource.wrap(new byte[9])).hasSize(3);
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\n" +
-                               "Expected size:<3> but was:<9> in:\n" +
-                               "<ByteSource.wrap(000000000000000000)>");
+      assertThat(e).hasMessage(String.format("%n" +
+                               "Expected size:<3> but was:<9> in:%n" +
+                               "<ByteSource.wrap(000000000000000000)>"));
       return;
     }
     fail("Assertion error expected");

--- a/src/test/java/org/assertj/guava/api/MultimapAssert_containsKeys_Test.java
+++ b/src/test/java/org/assertj/guava/api/MultimapAssert_containsKeys_Test.java
@@ -51,12 +51,12 @@ public class MultimapAssert_containsKeys_Test extends MultimapAssertBaseTest {
     try {
       assertThat(actual).containsKeys("Nets", "Bulls", "Knicks");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n"
-                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>\n"
-                                   + "to contain keys:\n"
-                                   + "  <[\"Nets\", \"Bulls\", \"Knicks\"]>\n"
-                                   + "but could not find:\n"
-                                   + "  <[\"Nets\", \"Knicks\"]>");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n"
+                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>%n"
+                                   + "to contain keys:%n"
+                                   + "  <[\"Nets\", \"Bulls\", \"Knicks\"]>%n"
+                                   + "but could not find:%n"
+                                   + "  <[\"Nets\", \"Knicks\"]>"));
       return;
     }
     fail("Assertion error expected");
@@ -68,10 +68,10 @@ public class MultimapAssert_containsKeys_Test extends MultimapAssertBaseTest {
       assertThat(actual).containsKeys("Nets");
     } catch (AssertionError e) {
       // error message shows that we were looking for a unique key (not many)
-      assertThat(e).hasMessage("\nExpecting:\n"
-                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>\n"
-                                   + "to contain key:\n"
-                                   + "  <\"Nets\">");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n"
+                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>%n"
+                                   + "to contain key:%n"
+                                   + "  <\"Nets\">"));
       return;
     }
     fail("Assertion error expected");

--- a/src/test/java/org/assertj/guava/api/MultimapAssert_containsValues_Test.java
+++ b/src/test/java/org/assertj/guava/api/MultimapAssert_containsValues_Test.java
@@ -52,12 +52,12 @@ public class MultimapAssert_containsValues_Test extends MultimapAssertBaseTest {
     try {
       assertThat(actual).containsValues("Magic Johnson", "Lebron James");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n"
-                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>\n"
-                                   + "to contain values:\n"
-                                   + "  <[\"Magic Johnson\", \"Lebron James\"]>\n"
-                                   + "but could not find:\n"
-                                   + "  <[\"Lebron James\"]>");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n"
+                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>%n"
+                                   + "to contain values:%n"
+                                   + "  <[\"Magic Johnson\", \"Lebron James\"]>%n"
+                                   + "but could not find:%n"
+                                   + "  <[\"Lebron James\"]>"));
       return;
     }
     fail("Assertion error expected");
@@ -69,10 +69,10 @@ public class MultimapAssert_containsValues_Test extends MultimapAssertBaseTest {
       assertThat(actual).containsValues("Lebron James");
     } catch (AssertionError e) {
       // error message shows that we were looking for a unique value (not many)
-      assertThat(e).hasMessage("\nExpecting:\n"
-                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>\n"
-                                   + "to contain value:\n"
-                                   + "  <\"Lebron James\">");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n"
+                                   + "  <{Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}>%n"
+                                   + "to contain value:%n"
+                                   + "  <\"Lebron James\">"));
       return;
     }
     fail("Assertion error expected");

--- a/src/test/java/org/assertj/guava/api/OptionalAssert_contains_Test.java
+++ b/src/test/java/org/assertj/guava/api/OptionalAssert_contains_Test.java
@@ -42,7 +42,7 @@ public class OptionalAssert_contains_Test extends BaseTest {
     final Optional<String> testedOptional = Optional.of("Test");
     // expect
     expectException(AssertionError.class,
-        "\nExpecting Optional to contain value \n<\"Test 2\">\n but contained \n<\"Test\">");
+        String.format("%nExpecting Optional to contain value %n<\"Test 2\">%n but contained %n<\"Test\">"));
     // when
     assertThat(testedOptional).contains("Test 2");
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasClosedLowerBound_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasClosedLowerBound_Test.java
@@ -39,10 +39,10 @@ public class RangeAssert_hasClosedLowerBound_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.openClosed(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n" +
-	                                      "Expecting:\n" +
-	                                      "  <(1‥10]>\n" +
-	                                      "to be closed in the lower bound but was opened");
+	expectException(AssertionError.class, String.format("%n" +
+	                                      "Expecting:%n" +
+	                                      "  <(1‥10]>%n" +
+	                                      "to be closed in the lower bound but was opened"));
 	// when
 	assertThat(actual).hasClosedLowerBound();
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasClosedUpperBound_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasClosedUpperBound_Test.java
@@ -39,10 +39,10 @@ public class RangeAssert_hasClosedUpperBound_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.closedOpen(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n" +
-	                                      "Expecting:\n" +
-	                                      "  <[1‥10)>\n" +
-	                                      "to be closed in the upper bound but was opened");
+	expectException(AssertionError.class, String.format("%n" +
+	                                      "Expecting:%n" +
+	                                      "  <[1‥10)>%n" +
+	                                      "to be closed in the upper bound but was opened"));
 	// when
 	assertThat(actual).hasClosedUpperBound();
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasLowerEndpointEqualTo_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasLowerEndpointEqualTo_Test.java
@@ -39,13 +39,13 @@ public class RangeAssert_hasLowerEndpointEqualTo_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.closed(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n" +
-	                                      "Expecting:\n" +
-	                                      "  <[1‥10]>\n" +
-	                                      "to have lower endpoint equal to:\n" +
-	                                      "  <2>\n" +
-	                                      "but was:\n" +
-	                                      "  <1>");
+	expectException(AssertionError.class, String.format("%n" +
+	                                      "Expecting:%n" +
+	                                      "  <[1‥10]>%n" +
+	                                      "to have lower endpoint equal to:%n" +
+	                                      "  <2>%n" +
+	                                      "but was:%n" +
+	                                      "  <1>"));
 	// when
 	assertThat(actual).hasLowerEndpointEqualTo(2);
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasOpenedLowerBound_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasOpenedLowerBound_Test.java
@@ -39,10 +39,10 @@ public class RangeAssert_hasOpenedLowerBound_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.closedOpen(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n"
-	                                      + "Expecting:\n"
-	                                      + "  <[1‥10)>\n"
-	                                      + "to be opened in the lower bound but was closed");
+	expectException(AssertionError.class, String.format("%n"
+	                                      + "Expecting:%n"
+	                                      + "  <[1‥10)>%n"
+	                                      + "to be opened in the lower bound but was closed"));
 	// when
 	assertThat(actual).hasOpenedLowerBound();
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasOpenedUpperBound_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasOpenedUpperBound_Test.java
@@ -39,10 +39,10 @@ public class RangeAssert_hasOpenedUpperBound_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.openClosed(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n"
-	                                      + "Expecting:\n"
-	                                      + "  <(1‥10]>\n"
-	                                      + "to be opened in the upper bound but was closed");
+	expectException(AssertionError.class, String.format("%n"
+	                                      + "Expecting:%n"
+	                                      + "  <(1‥10]>%n"
+	                                      + "to be opened in the upper bound but was closed"));
 	// when
 	assertThat(actual).hasOpenedUpperBound();
   }

--- a/src/test/java/org/assertj/guava/api/RangeAssert_hasUpperEndpointEqualTo_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeAssert_hasUpperEndpointEqualTo_Test.java
@@ -36,13 +36,13 @@ public class RangeAssert_hasUpperEndpointEqualTo_Test extends BaseTest {
 	// given
 	final Range<Integer> actual = Range.closed(1, 10);
 	// expect
-	expectException(AssertionError.class, "\n" +
-	                                      "Expecting:\n" +
-	                                      "  <[1‥10]>\n" +
-	                                      "to have upper endpoint equal to:\n" +
-	                                      "  <2>\n" +
-	                                      "but was:\n" +
-	                                      "  <10>");
+	expectException(AssertionError.class, String.format("%n" +
+	                                      "Expecting:%n" +
+	                                      "  <[1‥10]>%n" +
+	                                      "to have upper endpoint equal to:%n" +
+	                                      "  <2>%n" +
+	                                      "but was:%n" +
+	                                      "  <10>"));
 	// when
 	assertThat(actual).hasUpperEndpointEqualTo(2);
   }

--- a/src/test/java/org/assertj/guava/api/RangeMapAssert_containsKeys_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeMapAssert_containsKeys_Test.java
@@ -57,14 +57,14 @@ public class RangeMapAssert_containsKeys_Test extends RangeMapAssertBaseTest {
 	try {
 	  assertThat(actual).containsKeys(100, 200, 900);
 	} catch (AssertionError e) {
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
+	  assertThat(e).hasMessage(String.format("%n" +
+		                       "Expecting:%n" +
 		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)" +
-		                       "=yellow, [590‥620)=orange, [620‥750)=red]>\n" +
-		                       "to contain keys:\n" +
-		                       "  <[100, 200, 900]>\n" +
-		                       "but could not find:\n" +
-		                       "  <[100, 200, 900]>");
+		                       "=yellow, [590‥620)=orange, [620‥750)=red]>%n" +
+		                       "to contain keys:%n" +
+		                       "  <[100, 200, 900]>%n" +
+		                       "but could not find:%n" +
+		                       "  <[100, 200, 900]>"));
 	  return;
 	}
 	fail("Assertion error expected");
@@ -77,11 +77,11 @@ public class RangeMapAssert_containsKeys_Test extends RangeMapAssertBaseTest {
 	} catch (AssertionError e) {
 	  // error message shows that we were looking for a unique key (not many)
 	  // @format:off
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>\n" +
-		                       "to contain key:\n" +
-		                       "  <100>");
+	  assertThat(e).hasMessage(String.format("%n" +
+		                       "Expecting:%n" +
+		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>%n" +
+		                       "to contain key:%n" +
+		                       "  <100>"));
 	  // @format:on
 	  return;
 	}

--- a/src/test/java/org/assertj/guava/api/RangeMapAssert_containsValues_Test.java
+++ b/src/test/java/org/assertj/guava/api/RangeMapAssert_containsValues_Test.java
@@ -52,13 +52,13 @@ public class RangeMapAssert_containsValues_Test extends RangeMapAssertBaseTest {
 	  assertThat(actual).containsValues("violet", "black");
 	} catch (AssertionError e) {
 	  // @format:off
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>\n" +
-		                       "to contain values:\n" +
-		                       "  <[\"violet\", \"black\"]>\n" +
-		                       "but could not find:\n" +
-		                       "  <[\"black\"]>");
+	  assertThat(e).hasMessage(String.format("%n" +
+		                       "Expecting:%n" +
+		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>%n" +
+		                       "to contain values:%n" +
+		                       "  <[\"violet\", \"black\"]>%n" +
+		                       "but could not find:%n" +
+		                       "  <[\"black\"]>"));
 	  // @format:on
 	  return;
 	}
@@ -72,11 +72,11 @@ public class RangeMapAssert_containsValues_Test extends RangeMapAssertBaseTest {
 	} catch (AssertionError e) {
 	  // error message shows that we were looking for a unique value (not many)
 	  // @format:off
-	  assertThat(e).hasMessage("\n" +
-		                       "Expecting:\n" +
-		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>\n" +
-		                       "to contain value:\n" +
-		                       "  <\"black\">");
+	  assertThat(e).hasMessage(String.format("%n" +
+		                       "Expecting:%n" +
+		                       "  <[[380‥450)=violet, [450‥495)=blue, [495‥570)=green, [570‥590)=yellow, [590‥620)=orange, [620‥750)=red]>%n" +
+		                       "to contain value:%n" +
+		                       "  <\"black\">"));
 	  // @format:on
 	  return;
 	}

--- a/src/test/java/org/assertj/guava/api/TableAssert_containsCells_Test.java
+++ b/src/test/java/org/assertj/guava/api/TableAssert_containsCells_Test.java
@@ -42,12 +42,12 @@ public class TableAssert_containsCells_Test extends TableAssertBaseTest {
       assertThat(actual).containsCell(1, 4, "Millard Fillmore");
       fail("Assertion error expected.");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting row:<1> and column:<4> to have value:\n" +
-                               "  <Millard Fillmore>\n" +
-                               "but was:\n" +
-                               "  <Franklin Pierce>\n" +
-                               "in:\n" +
-                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>");
+      assertThat(e).hasMessage(String.format("%nExpecting row:<1> and column:<4> to have value:%n" +
+                               "  <Millard Fillmore>%n" +
+                               "but was:%n" +
+                               "  <Franklin Pierce>%n" +
+                               "in:%n" +
+                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>"));
       return;
     }
   }

--- a/src/test/java/org/assertj/guava/api/TableAssert_containsColumns_Test.java
+++ b/src/test/java/org/assertj/guava/api/TableAssert_containsColumns_Test.java
@@ -53,12 +53,12 @@ public class TableAssert_containsColumns_Test extends TableAssertBaseTest {
     try {
       assertThat(actual).containsColumns(9, 6);
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n" +
-                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>\n" +
-                               "to contain columns:\n" +
-                               "  <[9, 6]>\n" +
-                               "but could not find:\n" +
-                               "  <[6, 9]>");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n" +
+                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>%n" +
+                               "to contain columns:%n" +
+                               "  <[9, 6]>%n" +
+                               "but could not find:%n" +
+                               "  <[6, 9]>"));
       return;
     }
     fail("Assertion error expected.");

--- a/src/test/java/org/assertj/guava/api/TableAssert_containsRows_Test.java
+++ b/src/test/java/org/assertj/guava/api/TableAssert_containsRows_Test.java
@@ -53,12 +53,12 @@ public class TableAssert_containsRows_Test extends TableAssertBaseTest {
     try {
       assertThat(actual).containsRows(3, 4);
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n" +
-                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>\n" +
-                               "to contain rows:\n" +
-                               "  <[3, 4]>\n" +
-                               "but could not find:\n" +
-                               "  <[3, 4]>");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n" +
+                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>%n" +
+                               "to contain rows:%n" +
+                               "  <[3, 4]>%n" +
+                               "but could not find:%n" +
+                               "  <[3, 4]>"));
       return;
     }
     fail("Assertion error expected.");

--- a/src/test/java/org/assertj/guava/api/TableAssert_containsValues_Test.java
+++ b/src/test/java/org/assertj/guava/api/TableAssert_containsValues_Test.java
@@ -53,12 +53,12 @@ public class TableAssert_containsValues_Test extends TableAssertBaseTest {
     try {
       assertThat(actual).containsValues("James A. Garfield", "Andrew Johnson");
     } catch (AssertionError e) {
-      assertThat(e).hasMessage("\nExpecting:\n" +
-                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>\n" +
-                               "to contain values:\n" +
-                               "  <[\"James A. Garfield\", \"Andrew Johnson\"]>\n" +
-                               "but could not find:\n" +
-                               "  <[\"Andrew Johnson\", \"James A. Garfield\"]>");
+      assertThat(e).hasMessage(String.format("%nExpecting:%n" +
+                               "  <{1={4=Franklin Pierce, 3=Millard Fillmore}, 2={5=Grover Cleveland}}>%n" +
+                               "to contain values:%n" +
+                               "  <[\"James A. Garfield\", \"Andrew Johnson\"]>%n" +
+                               "but could not find:%n" +
+                               "  <[\"Andrew Johnson\", \"James A. Garfield\"]>"));
       return;
     }
     fail("Assertion error expected.");


### PR DESCRIPTION
…n (fixes #22)

When running findbugs I noticed #25 missed a lot of \n occurrences.

Sorry about that. :(