### PR TITLE
Remove dependency version ranges.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>[${guava.version},)</version>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>[${assertj-core.version}, 3.99.0]</version>
+      <version>${assertj-core.version}</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>


### PR DESCRIPTION
They cause more harm than good -- it can resolve to even prerelease versions
(e.g. 20.0-rc1)

Refs https://ceylon-lang.org/blog/2014/12/01/version-ranges/