### PR TITLE
Do not implicit upgrade Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
the <scope>provided</scope> prefents assertj-guava from adding a dependency to gauva, projects which use assertj-guava should have a this dependency out of the box and this one should not be applied (or even upgraded) by assertj