### PR TITLE
Remove version range for assertj-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>[${assertj-core.version}, 4.0)</version>
+      <version>${assertj-core.version}</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>


### PR DESCRIPTION
#34 is back from the dead!

This destroys build reproducibility (as the range is determined at build time)
and also causes issues for downsteam consumers of the assertj-guava artifact.

For example, currently the `jdbi` build uses `assertj-core:3.11.1` and `assertj-guava:3.2.0`
Since I was recently contributing to assertj, I now have a `assertj-core:3.12-SNAPSHOT` installed locally.

Maven finds this "newer" version and substitutes it as the `assertj-guava` dependency.
Then the versions checker plugin fails:

```
[INFO] --- maven-dependency-versions-check-plugin:2.0.4:check (default) @ jdbi3-guava ---
[INFO] Checking dependency versions
[ERROR] Found a problem with the direct dependency org.assertj:assertj-core of the current project
  Expected version is 3.11.1
  Resolved version is 3.11.1
  Version 3.12.0-SNAPSHOT was expected by artifact: org.assertj:assertj-guava
```

Even though I only depend on both the released versions, an *unreleased local build*
sneaks into my dependency tree due to this version range!