### PR TITLE
Upgrade assertj-core and Guava, add InstanceOfAssertFactories for Guava

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 2 space indentation for java, xml and yml files
+[*.{java,xml,yml,sh}]
+indent_style = space
+indent_size = 2

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.assertj</groupId>
     <artifactId>assertj-parent-pom</artifactId>
-    <version>2.1.9</version>
+    <version>2.2.5</version>
   </parent>
 
   <scm>
@@ -28,8 +28,8 @@
 
   <properties>
     <!-- guava 21+ is for java 8 -->
-    <guava.version>21.0</guava.version>
-    <assertj-core.version>3.11.1</assertj-core.version>
+    <guava.version>28.0-jre</guava.version>
+    <assertj-core.version>3.13.2</assertj-core.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/assertj/guava/api/Assertions.java
+++ b/src/main/java/org/assertj/guava/api/Assertions.java
@@ -33,7 +33,7 @@ import com.google.common.io.ByteSource;
  * @author Marcin Kwaczyński
  * @author Max Daniline
  */
-public class Assertions {
+public class Assertions implements InstanceOfAssertFactories {
 
   public static ByteSourceAssert assertThat(final ByteSource actual) {
     return new ByteSourceAssert(actual);
@@ -91,7 +91,7 @@ public class Assertions {
   }
 
   /**
-   * protected to avoid direct instanciation but allowing subclassing.
+   * protected to avoid direct instantiation but allowing subclassing.
    */
   protected Assertions() {
     // empty

--- a/src/main/java/org/assertj/guava/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/guava/api/InstanceOfAssertFactories.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import org.assertj.core.api.Assert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeMap;
+import com.google.common.collect.Table;
+import com.google.common.io.ByteSource;
+
+/**
+ * Guava {@link InstanceOfAssertFactory InstanceOfAssertFactories} for {@link Assert#asInstanceOf(InstanceOfAssertFactory)}.
+ *
+ * @author Stefano Cordio
+ * @since 3.2.2
+ */
+public interface InstanceOfAssertFactories {
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link ByteSource}.
+   */
+  InstanceOfAssertFactory<ByteSource, ByteSourceAssert> BYTE_SOURCE = new InstanceOfAssertFactory<>(ByteSource.class,
+                                                                                                    Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Multimap}, assuming {@code Object} as key and value types.
+   *
+   * @see #multimap(Class, Class)
+   */
+  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  InstanceOfAssertFactory<Multimap, MultimapAssert<Object, Object>> MULTIMAP = multimap(Object.class, Object.class);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Multimap}.
+   *
+   * @param <K>       the {@code Multimap} key type.
+   * @param <V>       the {@code Multimap} value type.
+   * @param keyType   the key type instance.
+   * @param valueType the value type instance.
+   * @return the factory instance.
+   * 
+   * @see #MULTIMAP
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <K, V> InstanceOfAssertFactory<Multimap, MultimapAssert<K, V>> multimap(Class<K> keyType, Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(Multimap.class, Assertions::<K, V> assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for an {@link Optional}, assuming {@code Object} as value type.
+   *
+   * @see #optional(Class)
+   */
+  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  InstanceOfAssertFactory<Optional, OptionalAssert<Object>> OPTIONAL = optional(Object.class);
+
+  /**
+   * {@link InstanceOfAssertFactory} for an {@link Optional}.
+   *
+   * @param <VALUE>    the {@code Optional} value type.
+   * @param resultType the value type instance.
+   * @return the factory instance.
+   * 
+   * @see #OPTIONAL
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <VALUE> InstanceOfAssertFactory<Optional, OptionalAssert<VALUE>> optional(Class<VALUE> resultType) {
+    return new InstanceOfAssertFactory<>(Optional.class, Assertions::<VALUE> assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Range}.
+   *
+   * @param <C>            the {@code Comparable} type.
+   * @param comparableType the comparable type instance.
+   * @return the factory instance.
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <C extends Comparable<C>> InstanceOfAssertFactory<Range, RangeAssert<C>> range(Class<C> comparableType) {
+    return new InstanceOfAssertFactory<>(Range.class, Assertions::<C> assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link RangeMap}.
+   *
+   * @param <K>       the {@code RangeMap} key type.
+   * @param <V>       the {@code RangeMap} value type.
+   * @param keyType   the key type instance.
+   * @param valueType the value type instance.
+   * @return the factory instance.
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <K extends Comparable<K>, V> InstanceOfAssertFactory<RangeMap, RangeMapAssert<K, V>> rangeMap(Class<K> keyType,
+                                                                                                       Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(RangeMap.class, Assertions::<K, V> assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Table}, assuming {@code Object} as row key type, column key type and
+   * value type.
+   *
+   * @see #table(Class, Class, Class)
+   */
+  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  InstanceOfAssertFactory<Table, TableAssert<Object, Object, Object>> TABLE = table(Object.class, Object.class, Object.class);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Table}.
+   *
+   * @param <R>           the {@code Table} row key type.
+   * @param <C>           the {@code Table} column key type.
+   * @param <V>           the {@code Table} value type.
+   * @param rowKeyType    the row key type instance.
+   * @param columnKeyType the column key type instance.
+   * @param valueType     the value type instance.
+   * @return the factory instance.
+   * 
+   * @see #TABLE
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <R, C, V> InstanceOfAssertFactory<Table, TableAssert<R, C, V>> table(Class<R> rowKeyType, Class<C> columnKeyType,
+                                                                              Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(Table.class, Assertions::<R, C, V> assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Multiset}, assuming {@code Object} as element type.
+   *
+   * @see #multiset(Class)
+   */
+  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  InstanceOfAssertFactory<Multiset, MultisetAssert<Object>> MULTISET = multiset(Object.class);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link Multiset}.
+   *
+   * @param <ELEMENT>   the {@code Multiset} element type.
+   * @param elementType the element type instance.
+   * @return the factory instance.
+   *
+   * @see #MULTISET
+   */
+  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  static <ELEMENT> InstanceOfAssertFactory<Multiset, MultisetAssert<ELEMENT>> multiset(Class<ELEMENT> elementType) {
+    return new InstanceOfAssertFactory<>(Multiset.class, Assertions::<ELEMENT> assertThat);
+  }
+
+}

--- a/src/test/java/org/assertj/guava/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/src/test/java/org/assertj/guava/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.from;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.Test;
+
+/**
+ * @author Stefano Cordio
+ * @since 3.2.2
+ */
+public class Assertions_sync_with_InstanceOfAssertFactories_Test {
+
+  private static final Class<?>[] FIELD_FACTORIES_IGNORED_TYPES = {
+      // There can be no Range field factory with a base type.
+      RangeAssert.class,
+      // There can be no RangeMap field factory with a base type.
+      RangeMapAssert.class,
+  };
+
+  private static final Class<?>[] METHOD_FACTORIES_IGNORED_TYPES = {
+  };
+
+  @Test
+  public void each_guava_assertion_should_have_an_instance_of_assert_factory_static_field() {
+    // GIVEN
+    Map<Type, Type> assertThatMethods = findAssertThatParameterAndReturnTypes();
+    // WHEN
+    Map<Type, Type> fieldFactories = findFieldFactoryTypes();
+    // THEN
+    then(fieldFactories).containsAllEntriesOf(assertThatMethods)
+                        .hasSameSizeAs(assertThatMethods);
+  }
+
+  @Test
+  public void each_guava_assertion_with_type_parameters_should_have_an_instance_of_assert_factory_static_method() {
+    // GIVEN
+    Map<Type, Type> assertThatMethods = findTypedAssertThatParameterAndReturnTypes();
+    // WHEN
+    Map<Type, Type> methodFactories = findMethodFactoryTypes();
+    // THEN
+    then(methodFactories).containsAllEntriesOf(assertThatMethods)
+                         .hasSameSizeAs(assertThatMethods);
+  }
+
+  private Map<Type, Type> findAssertThatParameterAndReturnTypes() {
+    return Stream.of(findAssertThatMethods(FIELD_FACTORIES_IGNORED_TYPES))
+                 .map(this::toParameterAndReturnTypeEntry)
+                 .filter(not(this::isPrimitiveTypeKey))
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private <K, V> boolean isPrimitiveTypeKey(Entry<K, V> entry) {
+    if (entry.getKey() instanceof Class) {
+      return ((Class<?>) entry.getKey()).isPrimitive();
+    }
+    return false;
+  }
+
+  private Map<Type, Type> findTypedAssertThatParameterAndReturnTypes() {
+    return Stream.of(findAssertThatMethods(METHOD_FACTORIES_IGNORED_TYPES))
+                 .filter(this::hasTypeParameters)
+                 .map(this::toParameterAndReturnTypeEntry)
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private static Method[] findAssertThatMethods(Class<?>... ignoredReturnTypes) {
+    Set<Class<?>> ignoredReturnTypesSet = newLinkedHashSet(ignoredReturnTypes);
+    return Arrays.stream(Assertions.class.getMethods())
+                 .filter(method -> method.getName().equals("assertThat"))
+                 .filter(method -> !ignoredReturnTypesSet.contains(method.getReturnType()))
+                 .toArray(Method[]::new);
+  }
+
+  private boolean hasTypeParameters(Method method) {
+    return method.getTypeParameters().length != 0;
+  }
+
+  private Entry<Type, Type> toParameterAndReturnTypeEntry(Method method) {
+    return entry(normalize(genericParameterType(method)), normalize(method.getGenericReturnType()));
+  }
+
+  private Type genericParameterType(Method method) {
+    Type[] parameterTypes = method.getGenericParameterTypes();
+    assertThat(parameterTypes).hasSize(1);
+    return parameterTypes[0];
+  }
+
+  private Map<Type, Type> findFieldFactoryTypes() {
+    return Stream.of(InstanceOfAssertFactories.class.getFields())
+                 .filter(not(Field::isSynthetic)) // Exclude $jacocoData - see #590 and jacoco/jacoco#168
+                 .map(Field::getGenericType)
+                 .map(this::extractTypeParameters)
+                 .filter(not(this::isIgnoredFieldFactory))
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private boolean isIgnoredFieldFactory(Entry<Type, Type> e) {
+    return isIgnoredFactory(e, FIELD_FACTORIES_IGNORED_TYPES);
+  }
+
+  private Map<Type, Type> findMethodFactoryTypes() {
+    return Stream.of(InstanceOfAssertFactories.class.getMethods())
+                 .map(Method::getGenericReturnType)
+                 .map(this::extractTypeParameters)
+                 .filter(not(this::isIgnoredMethodFactory))
+                 .collect(toMap(Entry::getKey, Entry::getValue));
+  }
+
+  private boolean isIgnoredMethodFactory(Entry<Type, Type> e) {
+    return isIgnoredFactory(e, METHOD_FACTORIES_IGNORED_TYPES);
+  }
+
+  private boolean isIgnoredFactory(Entry<Type, Type> e, Class<?>... ignoredTypes) {
+    return Stream.of(ignoredTypes).anyMatch(type -> e.getValue().equals(type));
+  }
+
+  private Entry<Type, Type> extractTypeParameters(Type type) {
+    assertThat(type).asInstanceOf(type(ParameterizedType.class))
+                    .returns(InstanceOfAssertFactory.class, from(ParameterizedType::getRawType))
+                    .extracting(ParameterizedType::getActualTypeArguments)
+                    .asInstanceOf(ARRAY)
+                    .hasSize(2);
+    Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
+    return entry(normalize(typeArguments[0]), normalize(typeArguments[1]));
+  }
+
+  private Type normalize(Type type) {
+    if (type instanceof ParameterizedType) {
+      return ((ParameterizedType) type).getRawType();
+    } else if (type instanceof TypeVariable) {
+      Type[] bounds = ((TypeVariable<?>) type).getBounds();
+      assertThat(bounds).hasSize(1);
+      return normalize(bounds[0]);
+    }
+    return type;
+  }
+
+  // Borrowed from JDK 11
+  private static <T> Predicate<T> not(Predicate<T> target) {
+    return target.negate();
+  }
+
+}

--- a/src/test/java/org/assertj/guava/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/guava/api/InstanceOfAssertFactoriesTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.InstanceOfAssertFactories.*;
+
+import java.io.IOException;
+
+import org.assertj.guava.data.MapEntry;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableRangeMap;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Range;
+import com.google.common.io.ByteSource;
+
+/**
+ * @author Stefano Cordio
+ * @since 3.2.2
+ */
+public class InstanceOfAssertFactoriesTest {
+
+  @Test
+  public void byte_source_factory_should_allow_byte_source_assertions() throws IOException {
+    // GIVEN
+    Object value = ByteSource.empty();
+    // WHEN
+    ByteSourceAssert result = assertThat(value).asInstanceOf(BYTE_SOURCE);
+    // THEN
+    result.isEmpty();
+  }
+
+  @Test
+  public void multimap_factory_should_allow_multimap_assertions() {
+    // GIVEN
+    Object value = ImmutableMultimap.of("key", "value");
+    // WHEN
+    MultimapAssert<Object, Object> result = assertThat(value).asInstanceOf(MULTIMAP);
+    // THEN
+    result.contains(Assertions.entry("key", "value"));
+  }
+
+  @Test
+  public void typed_multimap_factory_should_allow_typed_multimap_assertions() {
+    // GIVEN
+    Object value = ImmutableMultimap.of("key", "value");
+    // WHEN
+    MultimapAssert<String, String> result = assertThat(value).asInstanceOf(multimap(String.class, String.class));
+    // THEN
+    result.contains(Assertions.entry("key", "value"));
+  }
+
+  @Test
+  public void optional_factory_should_allow_optional_assertions() {
+    // GIVEN
+    Object value = Optional.of("something");
+    // WHEN
+    OptionalAssert<Object> result = assertThat(value).asInstanceOf(OPTIONAL);
+    // THEN
+    result.isPresent();
+  }
+
+  @Test
+  public void typed_optional_factory_should_allow_typed_optional_assertions() {
+    // GIVEN
+    Object value = Optional.of("something");
+    // WHEN
+    OptionalAssert<String> result = assertThat(value).asInstanceOf(optional(String.class));
+    // THEN
+    result.isPresent();
+  }
+
+  @Test
+  public void range_factory_should_allow_range_assertions() {
+    // GIVEN
+    Object value = Range.atLeast(0);
+    // WHEN
+    RangeAssert<Integer> result = assertThat(value).asInstanceOf(range(Integer.class));
+    // THEN
+    result.contains(0);
+  }
+
+  @Test
+  public void range_map_factory_should_allow_range_map_assertions() {
+    // GIVEN
+    Object value = ImmutableRangeMap.of(Range.atLeast(0), "value");
+    // WHEN
+    RangeMapAssert<Integer, String> result = assertThat(value).asInstanceOf(rangeMap(Integer.class, String.class));
+    // THEN
+    result.contains(MapEntry.entry(0, "value"));
+  }
+
+  @Test
+  public void table_factory_should_allow_table_assertions() {
+    // GIVEN
+    Object value = ImmutableTable.of(0, 0.0, "value");
+    // WHEN
+    TableAssert<Object, Object, Object> result = assertThat(value).asInstanceOf(TABLE);
+    // THEN
+    result.containsCell(0, 0.0, "value");
+  }
+
+  @Test
+  public void typed_table_factory_should_allow_typed_table_assertions() {
+    // GIVEN
+    Object value = ImmutableTable.of(0, 0.0, "value");
+    // WHEN
+    TableAssert<Integer, Double, String> result = assertThat(value).asInstanceOf(table(Integer.class, Double.class,
+                                                                                       String.class));
+    // THEN
+    result.containsCell(0, 0.0, "value");
+  }
+
+  @Test
+  public void multiset_factory_should_allow_multiset_assertions() {
+    // GIVEN
+    Object value = ImmutableMultiset.of("value");
+    // WHEN
+    MultisetAssert<Object> result = assertThat(value).asInstanceOf(MULTISET);
+    // THEN
+    result.containsAtLeast(1, "value");
+  }
+
+  @Test
+  public void typed_multiset_factory_should_allow_typed_multiset_assertions() {
+    // GIVEN
+    Object value = ImmutableMultiset.of("value");
+    // WHEN
+    MultisetAssert<String> result = assertThat(value).asInstanceOf(multiset(String.class));
+    // THEN
+    result.containsAtLeast(1, "value");
+  }
+
+}


### PR DESCRIPTION
This PR introduces `InstanceOfAssertFactories` for Guava, following joel-costigliola/assertj-core#1498.

~`assertj-core` 3.13.2 should be released in few days, I'll update this PR once it is available.~

`assertj-core` has been upgraded to 3.13.2.